### PR TITLE
헬스 체크 자동으로 수행하도록 추가

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -9,3 +9,7 @@ hooks:
     - location: scripts/start_docker.sh
       timeout: 300
       runas: ec2-user
+  AfterInstall:
+    - location: scripts/health_check.sh
+      timeout: 60
+      runas: ec2-user

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+HEALTH_CHECK_URL="http://localhost:8080/health"
+
+for i in {1..10}; do
+    RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" ${HEALTH_CHECK_URL})
+    if [ "$RESPONSE" == "200" ]; then
+        echo "Health check successful"
+        exit 0
+    fi
+    echo "Health check failed. Retrying in 10 seconds..."
+    sleep 10
+done
+
+echo "Health check failed after multiple attempts"
+exit 1


### PR DESCRIPTION
### 요약
CodeDeploy 배포 후 애플리케이션의 정상 실행 여부를 확인하기 위한 헬스 체크 스크립트를 추가했습니다.

## 변경 사항
- scripts/health_check.sh 파일 추가:

1. 헬스 체크 경로: http://localhost:8080/health에서 애플리케이션의 상태를 확인.

2. 10회 반복 확인: 10초 간격으로 최대 10회까지 헬스 체크를 시도하며, 200 OK 응답이 확인되면 성공으로 간주.

- 응답이 없거나 실패 시, 최종적으로 배포 실패 처리.

- appspec.yml에 헬스 체크 스크립트 실행 단계 추가:

- AfterInstall 단계에 scripts/health_check.sh 실행을 포함하여 배포 후 헬스 체크를 수행하도록 설정.

### 목적
- CodeDeploy 배포 후 애플리케이션이 정상적으로 실행되었는지 검증하기 위해, 헬스 체크 스크립트를 추가하여 배포의 안정성과 신뢰성을 높이기 위함입니다.