### PR TITLE
CD : actuator를 이용해 헬스 체크 추가

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -7,7 +7,7 @@ files:
 hooks:
   ApplicationStart:
     - location: scripts/start_docker.sh
-      timeout: 300
+      timeout: 60
       runas: ec2-user
   AfterInstall:
     - location: scripts/health_check.sh

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 
 	// OAuth2 클라이언트
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// for health check
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,10 +38,16 @@ spring:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
       ddl-auto: update
-
-
 kakao:
   client_id: ${KAKAO_CLIENT_ID}
   redirect_uri: ${REDIRECT_URI}
-
+# Actuator 설정 추가
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always
 


### PR DESCRIPTION
### 요약
- 헬스 체크를 위해 spring actuator를 이용해 /health로 헬스 체크하도록 추가

## 이슈 : 헬스체크
## 🔘Part

- [x] Cloud

  <br/>

## 🔎 작업 내용

- spring actuator dependency 추가
- 헬스 체크를 위해 spring actuator를 이용해 /health로 헬스 체크할 수 있도록 설정 추가
- application start time out 시간도 60으로 수정
